### PR TITLE
Connect before STARTTLS

### DIFF
--- a/async_sender/api.py
+++ b/async_sender/api.py
@@ -304,10 +304,10 @@ class Connection:
             cert_bundle=self.mail.cert_bundle,
         )
 
+        await server.connect()
+
         if self.mail.use_starttls:
             await server.starttls()
-
-        await server.connect()
 
         if self.mail.username and self.mail.password:
             await server.login(self.mail.username, self.mail.password)


### PR DESCRIPTION
STARTTLS requires connecting to the server first:

https://aiosmtplib.readthedocs.io/en/stable/client.html#starttls-connections

Doing STARTTLS without connecting to the server first results in a `SMTPServerDisconnected`. This PR fixes that.